### PR TITLE
Bug/fix options filter

### DIFF
--- a/lib/dotloop_api/end_points/param_helper.rb
+++ b/lib/dotloop_api/end_points/param_helper.rb
@@ -4,7 +4,7 @@ module DotloopApi
       include Virtus.model
       attribute :batch_number, Integer, default: 1
       attribute :batch_size, Integer, default: 100
-      attribute :filter
+      attribute :filter, Hash
       attribute :include_details, Boolean, default: false
       attribute :sort_key
       attribute :sort_direction, String, default: 'asc'
@@ -18,7 +18,7 @@ module DotloopApi
         {
           batch_number: @batch_number.to_i,
           batch_size: size,
-          filter: filter_hash,
+          filter: filter_string,
           include_details: @include_details,
           sort: sort
         }.delete_if { |_, v| should_delete(v) }
@@ -52,8 +52,13 @@ module DotloopApi
           ((value.is_a?(String) || value.is_a?(Hash)) && value.empty?)
       end
 
-      def filter_hash
-        (@filter.to_s.split('&').map { |var| var.split('=') }).to_h.slice(*FILTER_OPTIONS)
+      def filter_string
+        @filter.map { |key, value| filter_pair(key, value) }.compact.join(',')
+      end
+
+      def filter_pair(key, value)
+        return unless FILTER_OPTIONS.include?(key.to_s)
+        key.to_s + '=' + value.to_s
       end
     end
   end

--- a/lib/dotloop_api/end_points/param_helper.rb
+++ b/lib/dotloop_api/end_points/param_helper.rb
@@ -53,6 +53,7 @@ module DotloopApi
       end
 
       def filter_string
+        return unless @filter
         @filter.map { |key, value| filter_pair(key, value) }.compact.join(',')
       end
 

--- a/lib/dotloop_api/version.rb
+++ b/lib/dotloop_api/version.rb
@@ -1,3 +1,3 @@
 module DotloopApi
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end

--- a/spec/end_points/param_helper_spec.rb
+++ b/spec/end_points/param_helper_spec.rb
@@ -12,14 +12,16 @@ describe DotloopApi::EndPoints::ParamHelper do
   end
 
   describe 'filter' do
-    it 'only allows specific filters' do
-      filter_string = 'transaction_type=PURCHASE_OFFER&other=123&transaction_status=PRE_OFFER|PRE_LISTING'
-      expect(params(filter: filter_string)).to include(
-        filter: {
-          'transaction_type' => 'PURCHASE_OFFER',
-          'transaction_status' => 'PRE_OFFER|PRE_LISTING'
-        }
-      )
+    it 'strigfies a given hash' do
+      filter_hash = { transaction_type: 'PURCHASE_OFFER', transaction_status: 'ARCHIVED' }
+      filter_string = 'transaction_type=PURCHASE_OFFER,transaction_status=ARCHIVED'
+      expect(params(filter: filter_hash)).to include(filter: filter_string)
+    end
+
+    it 'ignores unknown filters' do
+      filter_hash = { transaction_type: 'PURCHASE_OFFER', random: 123 }
+      filter_string = 'transaction_type=PURCHASE_OFFER'
+      expect(params(filter: filter_hash)[:filter]).to eq(filter_string)
     end
   end
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/163928573

filter options already existed but they weren't really working
the result from the api was always the same, regardless of the filters passed in

now this changes allow us to send a hash of filters to the gem
```
...
profile = client.Profile.find(id: 1)
profile.loops({ filters: { updated_min: "2017-05-30T21:42:17Z" } })
```