### PR TITLE
Widen ActiveSupport to support Rails 7 and 8, bump to 3.1.0

### DIFF
--- a/dotloop_api.gemspec
+++ b/dotloop_api.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '~> 7'
+  spec.add_runtime_dependency 'activesupport', '>= 7', '< 9'
   spec.add_runtime_dependency 'httparty', '~> 0.21'
   spec.add_runtime_dependency 'plissken', '~> 2'
   spec.add_runtime_dependency 'virtus', '~> 1.0'

--- a/lib/dotloop_api/version.rb
+++ b/lib/dotloop_api/version.rb
@@ -1,3 +1,3 @@
 module DotloopApi
-  VERSION = '3.0.2'.freeze
+  VERSION = '3.1.0'.freeze
 end


### PR DESCRIPTION
## Summary
- Widens `activesupport` dependency from `~> 7` to `>= 7, < 9` to support Rails 8 projects
- Bumps gem version from 3.0.2 to 3.1.0
- The gem only uses stable ActiveSupport core extensions (`camelize`, `constantize`, `symbolize_keys`), so this is a safe change

## Test plan
- [ ] Verify `bundle install` resolves successfully in a Rails 7 project
- [ ] Verify `bundle install` resolves successfully in a Rails 8 project
- [ ] Confirm gem functionality works in both environments